### PR TITLE
add support for DataDog events

### DIFF
--- a/lib/DataDog/DogStatsd.pm
+++ b/lib/DataDog/DogStatsd.pm
@@ -9,6 +9,15 @@ our $VERSION = '0.04';
 
 use IO::Socket::INET;
 
+my %OPTS_KEYS = (
+	date_happened    => 'd',
+	hostname         => 'h',
+	aggregation_key  => 'k',
+	priority         => 'p',
+	source_type_name => 's',
+	alert_type       => 't'
+);
+
 sub new {
 	my $classname = shift;
 	my $class = ref( $classname ) || $classname;
@@ -106,6 +115,44 @@ sub set {
 	my $value = shift;
 	my $opts  = shift || {};
 	$self->send_stats( $stat, $value, 's', $opts );
+}
+
+sub event {
+	my $self  = shift;
+	my $title = shift;
+	my $text  = shift;
+	my $opts  = shift || {};
+
+	my $event_string = format_event( $title, $text, $opts );
+
+	$self->send_to_socket($event_string);
+}
+
+sub format_event {
+	my $title = shift;
+	my $text  = shift;
+	my $opts  = shift || {};
+
+	my $tags = delete $opts->{tags};
+
+	$title =~ s/\n/\\n/g;
+	$text =~ s/\n/\\n/g;
+
+	my $event_string_data = sprintf "_e{%d,%d}:%s|%s",
+	length($title), length($text), $title, $text;
+
+	for my $opt ( keys %$opts ) {
+		if ( my $key = $OPTS_KEYS{$opt} ) {
+			$opts->{$opt} =~ s/|//g;
+			$event_string_data .= "|$key:$opts->{$opt}";
+		}
+	}
+
+	if ($tags) {
+		$event_string_data .= "|#" . join ",", map { s/|//g; $_ } @$tags;
+	}
+
+	return $event_string_data;
 }
 
 sub send_stats {

--- a/lib/DataDog/DogStatsd.pm
+++ b/lib/DataDog/DogStatsd.pm
@@ -284,6 +284,10 @@ Sends a timing (in ms) for the given stat to the statsd server. The sample_rate 
 
 Sends a value to be tracked as a set to the statsd server.
 
+=head2 event
+
+	$statsd->event('event title', 'event text', { tags => ['tag1, 'tag2'] });
+
 =head1 AUTHORS
 
 Stefan Goethals <stefan@zipkid.eu>

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -16,4 +16,6 @@ $statsd->decrement( 'test.stats', { tags => ['tag1', 'tag2'] } );
 $statsd->timing( 'test.timing', 1, { tags => ['tag1', 'tag2'] } );
 $statsd->gauge('test.gauge', 10, { tags => ['tag1', 'tag2'] } );
 
+$statsd->event('event title', 'event description!');
+
 done_testing;

--- a/t/02_mockserver.t
+++ b/t/02_mockserver.t
@@ -62,6 +62,12 @@ $statsd->event('test event', 'test description', { tags => [ 'tag1', 'tag2' ] } 
 ($msg) = MockServer::get_and_reset_messages();
 is $msg, '_e{10,16}:test event|test description|#tag1,tag2';
 
+$statsd->event('test event', 'test description',
+    { hostname => "host", tags => [ 'tag1', 'tag2' ] } );
+($msg) = MockServer::get_and_reset_messages();
+is $msg, '_e{10,16}:test event|test description|h:host|#tag1,tag2';
+
+
 ## test namespace
 $statsd->namespace('test2.');
 $statsd->increment( 'stats' );

--- a/t/02_mockserver.t
+++ b/t/02_mockserver.t
@@ -54,6 +54,14 @@ $statsd->gauge('test.gauge', 10, { tags => ['tag1', 'tag2'] } );
 ($msg) = MockServer::get_and_reset_messages();
 is $msg, 'test.gauge:10|g|#tag1,tag2';
 
+$statsd->event('test event', 'test description');
+($msg) = MockServer::get_and_reset_messages();
+is $msg, '_e{10,16}:test event|test description';
+
+$statsd->event('test event', 'test description', { tags => [ 'tag1', 'tag2' ] } );
+($msg) = MockServer::get_and_reset_messages();
+is $msg, '_e{10,16}:test event|test description|#tag1,tag2';
+
 ## test namespace
 $statsd->namespace('test2.');
 $statsd->increment( 'stats' );


### PR DESCRIPTION
This adds a new `event` method that submits an event to DataDog. Tests were added as well.
